### PR TITLE
Created Spec-Utils to handle common api request config and common

### DIFF
--- a/src/test/java/com/api/test/CountApiTest.java
+++ b/src/test/java/com/api/test/CountApiTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtils;
+
 import static com.api.constants.Role.*;
 import static com.api.utils.AuthTokenProvider.*;
 import static com.api.utils.ConfigManager.*;
@@ -18,21 +20,13 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 public class CountApiTest {
 	@Test
 	public void countApiTest() throws IOException {
-		Header authHeader = new Header("Authorization",getToken(FD));
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.contentType(ContentType.JSON)
-		.header(authHeader)
-		.log().uri()
-		.log().method()
-		.log().headers()
+        .spec(SpecUtils.requestSpecWithAuth(FD))
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(200)
+		.spec(SpecUtils.responseSpec())
 		.body("message", equalTo("Success")) //this is Matchers method i am not writing Matchers because I used static imports
-		.time(lessThan(5000L))
 		.body("data", notNullValue())
 		.body("data.size()", equalTo(3))
 		.body("data.count", everyItem(greaterThanOrEqualTo(0)))
@@ -45,16 +39,11 @@ public class CountApiTest {
 	@Test
 	public void countApiTest_MissingAuth() throws IOException {
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.contentType(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtils.requestSpec())
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtils.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/test/LoginApiTest.java
+++ b/src/test/java/com/api/test/LoginApiTest.java
@@ -1,16 +1,14 @@
 package com.api.test;
-import static io.restassured.RestAssured.*;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.lessThan;
 
 import java.io.IOException;
 
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
-import static com.api.utils.ConfigManager.*;
+import com.api.utils.SpecUtils;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class LoginApiTest {
@@ -18,23 +16,13 @@ public class LoginApiTest {
 	public void loginApiTest() throws IOException {
 			UserCredentials userCredentials = new UserCredentials("iamfd","password");
 			given()
-				.baseUri(getProperty("BASE_URI")) //calling getproperty() using class name because method is static and we are not using className because of static import
-			.and()
-				.contentType(ContentType.JSON)
-				.accept(ContentType.JSON)
-				.body(userCredentials)
-				.log().uri()
-				.log().method()
-				.log().headers()
-				.log().body()
+				.spec(SpecUtils.requestSpec(userCredentials))
 			.when()
 				.post("login")
 			.then()
-				.log().all()
-				.statusCode(200)
-				.time(lessThan(5000L))
+				.spec(SpecUtils.responseSpec())
 				.body("message", equalTo("Success"))
-			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/loginResponseSchema.json"));
+			    .body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/loginResponseSchema.json"));
 			
 	}
 

--- a/src/test/java/com/api/test/MasterApiTest.java
+++ b/src/test/java/com/api/test/MasterApiTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtils;
+
 import static com.api.constants.Role.*;
 import static com.api.utils.AuthTokenProvider.*;
 import static com.api.utils.ConfigManager.*;
@@ -18,21 +20,14 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 public class MasterApiTest {
 	@Test
 	public void masterApiTest() throws IOException {
-		Header authHeader = new Header("Authorization",getToken(FD));
+
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.contentType(ContentType.JSON)
-		.header(authHeader)
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtils.requestSpecWithAuth(FD))
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(200)
+		.spec(SpecUtils.responseSpec())
 		.body("message", equalTo("Success")) //this is Matchers method i am not writing Matchers because I used static imports
-		.time(lessThan(5000L))
 		.body("data", notNullValue())
 		.body("data",hasKey("mst_oem"))
 		.body("data",hasKey("mst_model"))
@@ -49,16 +44,11 @@ public class MasterApiTest {
 	@Test
 	public void MasterApiTest_MissingAuth() throws IOException {
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.contentType(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().headers()
+		.spec(SpecUtils.requestSpec())
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtils.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/test/UserDetailsApiTest.java
+++ b/src/test/java/com/api/test/UserDetailsApiTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtils;
+
 import static com.api.constants.Role.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -21,25 +23,14 @@ import io.restassured.module.jsv.JsonSchemaValidator;
 public class UserDetailsApiTest {
 	@Test
 	public void userDetailsAPITest() throws IOException {
-		Header authHeader = new Header("Authorization",getToken(FD));
 
 		given()
-			.baseUri(getProperty("BASE_URI"))
-		.and()
-			.header(authHeader)
-		.and()
-			.accept(ContentType.JSON)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+			.spec(SpecUtils.requestSpecWithAuth(FD))
 		.when()
 			.get("userdetails")
 		.then()
-			.log().all()
-			.statusCode(200)
+			.spec(SpecUtils.responseSpec())
 			.body("message", equalTo("Success"))
-			.time(lessThan(4000L))
 			.and()
 			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/userDetailsResponseSchema.json"));
 

--- a/src/test/java/com/api/utils/SpecUtils.java
+++ b/src/test/java/com/api/utils/SpecUtils.java
@@ -1,0 +1,97 @@
+package com.api.utils;
+
+import java.io.IOException;
+
+import org.hamcrest.Matchers;
+
+import com.api.constants.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+import static com.api.utils.ConfigManager.*;
+
+public class SpecUtils {
+	public static RequestSpecification requestSpec() throws IOException {
+		RequestSpecification request = new RequestSpecBuilder()
+											.setBaseUri(getProperty("BASE_URI"))//calling getproperty() using class name because method is static and we are not using className because of static import
+											.setContentType(ContentType.JSON)
+											.setAccept(ContentType.JSON)
+											.log(LogDetail.URI)
+											.log(LogDetail.METHOD)
+											.log(LogDetail.HEADERS)
+											.log(LogDetail.BODY)
+											.build();
+		return request;
+	}
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) throws IOException {
+		RequestSpecification request = new RequestSpecBuilder()
+											.setBaseUri(getProperty("BASE_URI"))//calling getproperty() using class name because method is static and we are not using className because of static import
+											.setContentType(ContentType.JSON)
+											.setAccept(ContentType.JSON)
+											.addHeader("Authorization", AuthTokenProvider.getToken(role))
+											.log(LogDetail.URI)
+											.log(LogDetail.METHOD)
+											.log(LogDetail.HEADERS)
+											.log(LogDetail.BODY)
+											.build();
+		return request;
+	}
+	
+	
+
+	public static RequestSpecification requestSpec(Object payload) throws IOException {
+		RequestSpecification request = new RequestSpecBuilder()
+				.setBaseUri(getProperty("BASE_URI"))//calling getproperty() using class name because method is static and we are not using className because of static import
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.setBody(payload)
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+		return request;
+	}
+	
+	public static ResponseSpecification responseSpec() {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+															.expectContentType(ContentType.JSON)
+															.expectStatusCode(200)
+															.expectResponseTime(Matchers.lessThan(5000L))
+															.log(LogDetail.ALL)
+															.build();
+		return responseSpecification;
+														
+	}
+	
+	public static ResponseSpecification responseSpec_JSON(int statusCode) {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+															.expectContentType(ContentType.JSON)
+															.expectStatusCode(statusCode)
+															.expectResponseTime(Matchers.lessThan(5000L))
+															.log(LogDetail.ALL)
+															.build();
+		return responseSpecification;
+														
+	}
+	
+	public static ResponseSpecification responseSpec_TEXT(int statusCode) {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+															.expectStatusCode(statusCode)
+															.expectResponseTime(Matchers.lessThan(5000L))
+															.log(LogDetail.ALL)
+															.build();
+		return responseSpecification;
+														
+	}
+	
+
+
+}


### PR DESCRIPTION
Spec Utils consisting of common RequestSpecBuilder and ResponseSpecBuilder. These util method reduced boiler plate code in our api test and also reduced number of lines making test code smaller and maintainable.